### PR TITLE
Add comment on CloudEvents compliance pending (ref #105) in readiness checklist

### DIFF
--- a/documentation/API_documentation/population-density-data-API-Readiness-Checklist.md
+++ b/documentation/API_documentation/population-density-data-API-Readiness-Checklist.md
@@ -5,7 +5,10 @@ Checklist for population-density-data 0.3.0 in release r3.2
 | Nr | API release assets  | alpha | release-candidate |  initial<br>public | stable<br> public | Status | Reference information |
 |----|----------------------------------------------|:-----:|:-----------------:|:-------:|:------:|:----:|------|
 |  1 | API definition                               |   M   |         M         |    M    |    M   |   Y  | [link](/code/API_definitions/population-density-data.yaml) |
-|  2 | Design guidelines from Commonalities applied |   O   |         M         |    M    |    M   |   Y  | [r3.3](https://github.com/camaraproject/Commonalities/releases/tag/r3.2) |
+|  2 | Design guidelines from Commonalities applied |   O   |         M         |    M    |    M   |   Y  | [r3.3](https://github.com/camaraproject/Commonalities/releases/tag/r3.2) - The asynchronous response currently does not follow the CloudEvents delivery format as required by Commonalities r3.3. See Issue [#105](https://github.com/camaraproject/PopulationDensityData/issues/105). This will be addressed post-Fall’25 and released as v0.4.0 to ensure full compliance.
+
+⸻
+ |
 |  3 | Guidelines from ICM applied                  |   O   |         M         |    M    |    M   |   Y  | [r3.3](https://github.com/camaraproject/IdentityAndConsentManagement/releases/tag/r3.2) |
 |  4 | API versioning convention applied            |   M   |         M         |    M    |    M   |   Y  | v0.3.0 |
 |  5 | API documentation                            |   M   |         M         |    M    |    M   |   Y  | Embed documentation into API spec - [link](/code/API_definitions/population-density-data.yaml) |

--- a/documentation/API_documentation/population-density-data-API-Readiness-Checklist.md
+++ b/documentation/API_documentation/population-density-data-API-Readiness-Checklist.md
@@ -5,10 +5,7 @@ Checklist for population-density-data 0.3.0 in release r3.2
 | Nr | API release assets  | alpha | release-candidate |  initial<br>public | stable<br> public | Status | Reference information |
 |----|----------------------------------------------|:-----:|:-----------------:|:-------:|:------:|:----:|------|
 |  1 | API definition                               |   M   |         M         |    M    |    M   |   Y  | [link](/code/API_definitions/population-density-data.yaml) |
-|  2 | Design guidelines from Commonalities applied |   O   |         M         |    M    |    M   |   Y  | [r3.3](https://github.com/camaraproject/Commonalities/releases/tag/r3.2) - The asynchronous response currently does not follow the CloudEvents delivery format as required by Commonalities r3.3. See Issue [#105](https://github.com/camaraproject/PopulationDensityData/issues/105). This will be addressed post-Fall’25 and released as v0.4.0 to ensure full compliance.
-
-⸻
- |
+|  2 | Design guidelines from Commonalities applied |   O   |         M         |    M    |    M   |   Y  | [r3.3](https://github.com/camaraproject/Commonalities/releases/tag/r3.2)*** |
 |  3 | Guidelines from ICM applied                  |   O   |         M         |    M    |    M   |   Y  | [r3.3](https://github.com/camaraproject/IdentityAndConsentManagement/releases/tag/r3.2) |
 |  4 | API versioning convention applied            |   M   |         M         |    M    |    M   |   Y  | v0.3.0 |
 |  5 | API documentation                            |   M   |         M         |    M    |    M   |   Y  | Embed documentation into API spec - [link](/code/API_definitions/population-density-data.yaml) |
@@ -20,3 +17,5 @@ Checklist for population-density-data 0.3.0 in release r3.2
 | 11 | Change log updated                           |   M   |         M         |    M    |    M   |   Y  | [link](/CHANGELOG.md) |
 | 12 | Previous public release was certified        |   O   |         O         |    O    |    M   |   N  |  No  |
 | 13 | API description (for marketing)              |   O   |         O         |    M    |    M   |   Y  | [wiki link](https://lf-camaraproject.atlassian.net/wiki/spaces/CAM/pages/74448957/PopulationDensityData+API+description) |
+
+*** *The asynchronous response currently does not follow the CloudEvents delivery format as required by Commonalities r3.3. See Issue [#105](https://github.com/camaraproject/PopulationDensityData/issues/105). This will be addressed post-Fall’25 and released as v0.4.0 to ensure full compliance.*


### PR DESCRIPTION

#### What type of PR is this?

Add one of the following kinds:
* documentation


#### What this PR does / why we need it:

Adds a comment in the API Readiness Checklist regarding CloudEvents compliance (Commonalities r3.3). This documents the current gap and references the issue tracking its resolution, ensuring transparency and alignment with Release Management requirements.

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #105 

#### Special notes for reviewers:

This PR only updates documentation (readiness checklist). No functional or OAS changes are included. The actual fix will be handled in a later release (v0.2.0) as tracked in the referenced issue.

#### Changelog input

```
release-note
Added note in API Readiness Checklist regarding CloudEvents compliance (Commonalities r3.3), referencing follow-up issue.
```

#### Additional documentation 

This section can be blank.
N/A

```
docs

```
