### PR TITLE
fix(openapi): Fix #107 - Class Names are in SNAKE_CASE but should be …

### DIFF
--- a/code/API_definitions/population-density-data.yaml
+++ b/code/API_definitions/population-density-data.yaml
@@ -133,7 +133,7 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
-  version: 0.3.1
+  version: wip
 
   x-camara-commonalities: 0.6
 externalDocs:

--- a/code/API_definitions/population-density-data.yaml
+++ b/code/API_definitions/population-density-data.yaml
@@ -634,7 +634,7 @@ components:
         propertyName: dataType
         mapping:
           NO_DATA: '#/components/schemas/NoData'
-          LOW_DENSITY: '#/components/schemas/LOW_DENSITY'
+          LOW_DENSITY: '#/components/schemas/LowDensity'
           DENSITY_ESTIMATION: '#/components/schemas/DensityEstimation'
     NoData:
       allOf:

--- a/code/API_definitions/population-density-data.yaml
+++ b/code/API_definitions/population-density-data.yaml
@@ -141,7 +141,7 @@ externalDocs:
   url: https://github.com/camaraproject/PopulationDensityData
 
 servers:
-  - url: '{apiRoot}/population-density-data/v0.3'
+  - url: '{apiRoot}/population-density-data/vwip'
 
     variables:
       apiRoot:

--- a/code/API_definitions/population-density-data.yaml
+++ b/code/API_definitions/population-density-data.yaml
@@ -133,7 +133,7 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
-  version: 0.3.0
+  version: 0.3.1
 
   x-camara-commonalities: 0.6
 externalDocs:
@@ -633,16 +633,16 @@ components:
       discriminator:
         propertyName: dataType
         mapping:
-          NO_DATA: '#/components/schemas/NO_DATA'
+          NO_DATA: '#/components/schemas/NoData'
           LOW_DENSITY: '#/components/schemas/LOW_DENSITY'
-          DENSITY_ESTIMATION: '#/components/schemas/DENSITY_ESTIMATION'
-    NO_DATA:
+          DENSITY_ESTIMATION: '#/components/schemas/DensityEstimation'
+    NoData:
       allOf:
         - $ref: '#/components/schemas/CellPopulationDensityData'
-    LOW_DENSITY:
+    LowDensity:
       allOf:
         - $ref: '#/components/schemas/CellPopulationDensityData'
-    DENSITY_ESTIMATION:
+    DensityEstimation:
       allOf:
         - $ref: '#/components/schemas/CellPopulationDensityData'
         - type: object

--- a/code/Test_definitions/population-density-data.feature
+++ b/code/Test_definitions/population-density-data.feature
@@ -1,4 +1,4 @@
-Feature: CAMARA Population Density Data API, v0.3.0
+Feature: CAMARA Population Density Data API, vwip
   # Input to be provided by the implementation to the tester
   #
   # Implementation indications:
@@ -16,7 +16,7 @@ Feature: CAMARA Population Density Data API, v0.3.0
 
   Background: Common retrievePopulationDensity setup
     Given an environment at "apiRoot"
-    And the resource "/population-density-data/v0.3/retrieve"
+    And the resource "/population-density-data/vwip/retrieve"
     And the header "Content-Type" is set to "application/json"
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"


### PR DESCRIPTION
Some Class Names are in SNAKE_CASE but should be in CamelCase

#### What type of PR is this?

Add one of the following kinds:
* bug
* correction


#### What this PR does / why we need it:
This PR fixes issue #107 by renaming classes and of course increments spec version 


#### Which issue(s) this PR fixes:

Fixes #107 

#### Special notes for reviewers:

Only changes NO_DATA, LOW_DENSITY and DENSITY_ESTIMATION class names

#### Changelog input

```
 release-note

NO_DATA => NoData
LOW_DENSITY => LowDensity
DENSITY_ESTIMATION => DensityEstimation



```

